### PR TITLE
Upgrade Go version from 1.16 to 1.25

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/andream16/go-opentracing-example
 
-go 1.16
+go 1.25
 
 require (
 	github.com/HdrHistogram/hdrhistogram-go v1.0.1 // indirect

--- a/src/grpc-server/Dockerfile
+++ b/src/grpc-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16 as build
+FROM golang:1.25 as build
 
 WORKDIR /build
 

--- a/src/http-server-initiator/Dockerfile
+++ b/src/http-server-initiator/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16 as build
+FROM golang:1.25 as build
 
 WORKDIR /build
 

--- a/src/http-server-receiver/Dockerfile
+++ b/src/http-server-receiver/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16 as build
+FROM golang:1.25 as build
 
 WORKDIR /build
 

--- a/src/kafka-consumer/Dockerfile
+++ b/src/kafka-consumer/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16 as build
+FROM golang:1.25 as build
 
 WORKDIR /build
 


### PR DESCRIPTION
- Update go.mod to use Go 1.25
- Update all service Dockerfiles to use golang:1.25 base image
- Maintain compatibility with existing dependency management

Note: GitHub Actions workflow update requires workflow scope permissions